### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ script: npm run test
 sudo: required
 language: node_js
 node_js:
-  - "lts/*"
+  - "node"
+  - "10"
+  - "8"
+  - "6"
+install: npm install


### PR DESCRIPTION
Node.js 6, 8 and 10 are LTS and 11 is currently stable.

See https://github.com/nodejs/Release/blob/master/README.md

`lts/*` only picks the latest LTS branch, not all.